### PR TITLE
remove QString.chopped() to be Qt 5.9 compliant

### DIFF
--- a/src/lib/preferences/thememanager.cpp
+++ b/src/lib/preferences/thememanager.cpp
@@ -137,7 +137,8 @@ ThemeManager::Theme ThemeManager::parseTheme(const QString &path, const QString 
     info.name = metadata.name();
     info.description = metadata.comment();
     info.author = metadata.value(QSL("X-Falkon-Author")).toString();
-    info.themePath = path.chopped(1);
+    info.themePath = path;
+    info.themePath.chop(1);
 
     const QString iconName = metadata.icon();
     if (!iconName.isEmpty()) {


### PR DESCRIPTION
The `QString.chopped()` method was introduced in Qt 5.10, while Falkon requires at least Qt 5.9.0 in order to build. Trying to compile Falkon with for example Qt 5.9.5 (the latest available on Linux Mint 19.x repositories) results in a “has no member” error.